### PR TITLE
Add cancellation token overload to notification

### DIFF
--- a/CertiPay.Common.Notifications.Tests/Notifications/EmailServiceTests.cs
+++ b/CertiPay.Common.Notifications.Tests/Notifications/EmailServiceTests.cs
@@ -88,9 +88,9 @@ namespace CertiPay.Services.Notifications
         public async Task Test_Async_Send_Cancellation(string email)
         {
 
-            var timeOut = new CancellationTokenSource();
-            var timeOutToken = timeOut.Token;
-            timeOut.Cancel();
+            var cancel = new CancellationTokenSource();
+            var cancelToken = cancel.Token;
+            cancel.Cancel();
           
             IEmailService emailer = new EmailService(new SmtpClient());
 
@@ -98,7 +98,7 @@ namespace CertiPay.Services.Notifications
             {
                 msg.To.Add(email);
                 
-                await emailer.SendAsync(msg, timeOutToken);
+                await emailer.SendAsync(msg, cancelToken);
             }
 
         }

--- a/CertiPay.Common.Notifications.Tests/Notifications/EmailServiceTests.cs
+++ b/CertiPay.Common.Notifications.Tests/Notifications/EmailServiceTests.cs
@@ -3,6 +3,8 @@ using NUnit.Framework;
 using System;
 using System.Net.Mail;
 using CertiPay.Common;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace CertiPay.Services.Notifications
 {
@@ -15,7 +17,7 @@ namespace CertiPay.Services.Notifications
         [ExpectedException(ExpectedException = typeof(InvalidOperationException), ExpectedMessage = "A recipient must be specified.")]
         public void Should_Not_Email_Outsiders_NonProd(String email)
         {
-            
+
             IEmailService emailer = new EmailService(new System.Net.Mail.SmtpClient());
 
             using (var msg = new MailMessage { From = new MailAddress("test@test.com") })
@@ -29,7 +31,7 @@ namespace CertiPay.Services.Notifications
         [TestCase("mattgwagner@gmail.com")]
         [TestCase("jsmith@worksafepays.com")]
         [TestCase("jsmith@certipay.com")]
-        [TestCase("jeremy@jeremyandchana.com")]        
+        [TestCase("jeremy@jeremyandchana.com")]
         public void Should_Allow_Any_Email_When_Testing_Domains_Disabled(string email)
         {
 
@@ -63,6 +65,41 @@ namespace CertiPay.Services.Notifications
                 msg.To.Add(email);
 
                 emailer.Send(msg);
+            }
+
+        }
+
+        [TestCase("jthomas@certipay.com")]
+        public async Task Test_Async_Send(string email)
+        {
+
+            IEmailService emailer = new EmailService(new SmtpClient());
+
+            using (var msg = new MailMessage { From = new MailAddress("test@test.com") })
+            {
+                msg.To.Add(email);
+
+                await emailer.SendAsync(msg, CancellationToken.None);
+            }
+
+        }
+
+        [Test]
+        [TestCase("jthomas@certipay.com")]
+        public async Task Test_Async_Send_Cancellation(string email)
+        {
+
+            var timeOut = new CancellationTokenSource();
+            var timeOutToken = timeOut.Token;
+            timeOut.Cancel();
+          
+            IEmailService emailer = new EmailService(new SmtpClient());
+
+            using (var msg = new MailMessage { From = new MailAddress("test@test.com") })
+            {
+                msg.To.Add(email);
+                
+                await emailer.SendAsync(msg, timeOutToken);
             }
 
         }

--- a/CertiPay.Common.Notifications.Tests/Notifications/EmailServiceTests.cs
+++ b/CertiPay.Common.Notifications.Tests/Notifications/EmailServiceTests.cs
@@ -84,7 +84,6 @@ namespace CertiPay.Services.Notifications
 
         }
 
-        [Test]
         [TestCase("jthomas@certipay.com")]
         public async Task Test_Async_Send_Cancellation(string email)
         {

--- a/CertiPay.Common.Notifications/CertiPay.Common.Notifications.csproj
+++ b/CertiPay.Common.Notifications/CertiPay.Common.Notifications.csproj
@@ -50,6 +50,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\SmtpExtensions.cs" />
     <Compile Include="Notifications\EmailNotification.cs" />
     <Compile Include="Notifications\IEmailService.cs" />
     <Compile Include="Notifications\INotificationSender.cs" />

--- a/CertiPay.Common.Notifications/Extensions/SmtpExtensions.cs
+++ b/CertiPay.Common.Notifications/Extensions/SmtpExtensions.cs
@@ -12,6 +12,7 @@ namespace CertiPay.Common.Notifications.Extensions
     {
         /// <summary>
         /// Extension method to have SmtpClient's SendMailAsync respond to a CancellationToken
+        /// https://gist.github.com/mattbenic/400e3c039ab8ea3e33aa
         /// </summary>
         public static async Task SendMailAsync(
             this SmtpClient client,

--- a/CertiPay.Common.Notifications/Extensions/SmtpExtensions.cs
+++ b/CertiPay.Common.Notifications/Extensions/SmtpExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Mail;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CertiPay.Common.Notifications.Extensions
+{
+    public static class SmtpExtensions
+    {
+        /// <summary>
+        /// Extension method to have SmtpClient's SendMailAsync respond to a CancellationToken
+        /// </summary>
+        public static async Task SendMailAsync(
+            this SmtpClient client,
+            MailMessage message,
+            CancellationToken token)
+        {
+            Action cancelSend = () =>
+            {
+                client.SendAsyncCancel();
+            };
+            using (var reg = token.Register(cancelSend))
+            {
+                await client.SendMailAsync(message);
+            }
+        }
+    }
+}

--- a/CertiPay.Common.Notifications/Extensions/SmtpExtensions.cs
+++ b/CertiPay.Common.Notifications/Extensions/SmtpExtensions.cs
@@ -13,6 +13,7 @@ namespace CertiPay.Common.Notifications.Extensions
         /// <summary>
         /// Extension method to have SmtpClient's SendMailAsync respond to a CancellationToken
         /// https://gist.github.com/mattbenic/400e3c039ab8ea3e33aa
+        /// https://msdn.microsoft.com/en-us/library/system.net.mail.smtpclient.sendasynccancel(v=vs.110).aspx
         /// </summary>
         public static async Task SendMailAsync(
             this SmtpClient client,
@@ -23,10 +24,12 @@ namespace CertiPay.Common.Notifications.Extensions
             {
                 client.SendAsyncCancel();
             };
-            using (var reg = token.Register(cancelSend))
-            {
-                await client.SendMailAsync(message);
-            }
+
+            if (!token.IsCancellationRequested)
+                using (var reg = token.Register(cancelSend))
+                {
+                    await client.SendMailAsync(message);
+                }
         }
     }
 }

--- a/CertiPay.Common.Notifications/Notifications/IEmailService.cs
+++ b/CertiPay.Common.Notifications/Notifications/IEmailService.cs
@@ -31,7 +31,6 @@ namespace CertiPay.Common.Notifications
         /// Send message asynchronously
         /// </summary>
         /// <param name="message"></param>
-        /// <returns></returns>
         Task SendAsync(MailMessage message);
 
         /// <summary>
@@ -39,7 +38,6 @@ namespace CertiPay.Common.Notifications
         /// </summary>
         /// <param name="message"></param>
         /// <param name="token"></param>
-        /// <returns></returns>
         Task SendAsync(MailMessage message, CancellationToken token);
     }
 
@@ -93,22 +91,11 @@ namespace CertiPay.Common.Notifications
             this._smtp = smtp;
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="notification"></param>
-        /// <returns></returns>
         public async Task SendAsync(EmailNotification notification)
         {
             await SendAsync(notification, CancellationToken.None);
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="notification"></param>
-        /// <param name="token"></param>
-        /// <returns></returns>
         public async Task SendAsync(EmailNotification notification, CancellationToken token)
         {
             using (Log.Timer("EmailService.SendAsync", context: notification))
@@ -149,10 +136,6 @@ namespace CertiPay.Common.Notifications
             }
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="message"></param>
         public void Send(MailMessage message)
         {
             using (Log.Timer("EmailService.Send", context: ForLog(message)))
@@ -167,22 +150,11 @@ namespace CertiPay.Common.Notifications
             }
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="message"></param>
-        /// <returns></returns>
         public async Task SendAsync(MailMessage message)
         {
             await SendAsync(message, CancellationToken.None);
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="message"></param>
-        /// <param name="token"></param>
-        /// <returns></returns>
         public async Task SendAsync(MailMessage message, CancellationToken token)
         {
             FilterRecipients(message.To);
@@ -196,10 +168,6 @@ namespace CertiPay.Common.Notifications
 
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="addresses"></param>
         public virtual void FilterRecipients(MailAddressCollection addresses)
         {
             if (_allowedTestingDomainsEnabled)
@@ -220,12 +188,6 @@ namespace CertiPay.Common.Notifications
             // TODO Check blacklisted email addresses?
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="msg"></param>
-        /// <param name="attachment"></param>
-        /// <returns></returns>
         public async Task AttachUrl(MailMessage msg, EmailNotification.Attachment attachment)
         {
             using (HttpClient client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = true }) { Timeout = DownloadTimeout })

--- a/CertiPay.Common.Notifications/Notifications/IEmailService.cs
+++ b/CertiPay.Common.Notifications/Notifications/IEmailService.cs
@@ -161,11 +161,13 @@ namespace CertiPay.Common.Notifications
             FilterRecipients(message.CC);
             FilterRecipients(message.Bcc);
 
-            var result = _smtp.SendMailAsync(message, token);
-            await result;
-
-            Log.Info("Sent email {@message} ({status})", ForLog(message), result.Status);
-
+            await _smtp 
+                .SendMailAsync(message)
+                .ContinueWith(result =>
+                {
+                    Log.Info("Sent email {@message} ({status})", ForLog(message), result.Status);
+                })
+                .ConfigureAwait(false);
         }
 
         public virtual void FilterRecipients(MailAddressCollection addresses)

--- a/CertiPay.Common.Notifications/Notifications/INotificationSender.cs
+++ b/CertiPay.Common.Notifications/Notifications/INotificationSender.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 namespace CertiPay.Common.Notifications
 {
@@ -8,5 +9,10 @@ namespace CertiPay.Common.Notifications
         /// Send a notification asyncronously
         /// </summary>
         Task SendAsync(T notification);
+
+        /// <summary>
+        /// Send a notification asyncronously with a specified cancellation token
+        /// </summary>
+        Task SendAsync(T notification, CancellationToken token);
     }
 }

--- a/CertiPay.Common.Notifications/Notifications/ISMSService.cs
+++ b/CertiPay.Common.Notifications/Notifications/ISMSService.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Common.Logging;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Twilio;
 
@@ -35,6 +36,10 @@ namespace CertiPay.Common.Notifications
 
         public Task SendAsync(SMSNotification notification)
         {
+            return SendAsync(notification, CancellationToken.None);
+        }
+        public Task SendAsync(SMSNotification notification, CancellationToken token)
+        {
             using (Log.Timer("SMSNotification.SendAsync", context: notification))
             {
                 // TODO Add error handling
@@ -43,7 +48,8 @@ namespace CertiPay.Common.Notifications
 
                 foreach (var recipient in notification.Recipients)
                 {
-                    client.SendSmsMessage(_twilioSourceNumber, recipient, notification.Content);
+                    if (!token.IsCancellationRequested)
+                        client.SendSmsMessage(_twilioSourceNumber, recipient, notification.Content);
                 }
 
                 return Task.FromResult(0);

--- a/CertiPay.Common.Notifications/Notifications/NoOpNotificationSender.cs
+++ b/CertiPay.Common.Notifications/Notifications/NoOpNotificationSender.cs
@@ -1,4 +1,5 @@
 ﻿using CertiPay.Common.Logging;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CertiPay.Common.Notifications.Notifications
@@ -14,11 +15,20 @@ namespace CertiPay.Common.Notifications.Notifications
 
         public Task SendAsync(EmailNotification notification)
         {
+            return SendAsync(notification, CancellationToken.None);
+        }
+        public Task SendAsync(EmailNotification notification, CancellationToken token)
+        {
             Log.Info("NoOpNotificationSender not sending {@notification}", notification);
             return Task.FromResult(0);
         }
 
         public Task SendAsync(SMSNotification notification)
+        {
+            return SendAsync(notification, CancellationToken.None);
+        }
+
+        public Task SendAsync(SMSNotification notification, CancellationToken token)
         {
             Log.Info("NoOpNotificationSender not sending {@notification}", notification);
             return Task.FromResult(0);

--- a/CertiPay.Common.Notifications/Notifications/NoOpNotificationSender.cs
+++ b/CertiPay.Common.Notifications/Notifications/NoOpNotificationSender.cs
@@ -15,8 +15,9 @@ namespace CertiPay.Common.Notifications.Notifications
 
         public Task SendAsync(EmailNotification notification)
         {
-            return SendAsync(notification, CancellationToken.None);
+			return SendAsync(notification, CancellationToken.None);
         }
+
         public Task SendAsync(EmailNotification notification, CancellationToken token)
         {
             Log.Info("NoOpNotificationSender not sending {@notification}", notification);

--- a/CertiPay.Common.Notifications/Notifications/QueuedSender.cs
+++ b/CertiPay.Common.Notifications/Notifications/QueuedSender.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Common.Logging;
 using CertiPay.Common.WorkQueue;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CertiPay.Common.Notifications
@@ -22,13 +23,20 @@ namespace CertiPay.Common.Notifications
 
         public async Task SendAsync(EmailNotification notification)
         {
+            await SendAsync(notification, CancellationToken.None); 
+        }
+        public async Task SendAsync(EmailNotification notification, CancellationToken token)
+        {
             using (Log.Timer("QueuedSender.SendAsync", context: notification))
             {
                 await _queue.Enqueue(EmailNotification.QueueName, notification);
             }
         }
-
         public async Task SendAsync(SMSNotification notification)
+        {
+            await SendAsync(notification, CancellationToken.None);
+        }
+        public async Task SendAsync(SMSNotification notification, CancellationToken token)
         {
             using (Log.Timer("QueuedSender.SendAsync", context: notification))
             {

--- a/CertiPay.Common.Notifications/Notifications/ServiceSender.cs
+++ b/CertiPay.Common.Notifications/Notifications/ServiceSender.cs
@@ -44,7 +44,7 @@ namespace CertiPay.Notifications
         {
             using (Log.Timer("ServiceSender.SendAsync", context: notification, warnIfExceeds: this.Timeout))
             {
-                await Post("/SMS", notification);
+                await Post("/SMS", notification, token);
             }
         }
 
@@ -57,17 +57,17 @@ namespace CertiPay.Notifications
         {
             using (Log.Timer("ServiceSender.SendAsync", context: notification, warnIfExceeds: this.Timeout))
             {
-                await Post("/Emails", notification);
+                await Post("/Emails", notification, token);
             }
         }
 
-        protected virtual async Task Post<T>(String resource, T t)
+        protected virtual async Task Post<T>(String resource, T t, CancellationToken token)
         {
             var json = Serializer.Serialize(t);
 
             var content = new StringContent(json, Encoding.Default, "application/json");
 
-            await GetClient().PostAsync(resource, content);
+            await GetClient().PostAsync(resource, content, token);
         }
 
         protected virtual HttpClient GetClient()

--- a/CertiPay.Common.Notifications/Notifications/ServiceSender.cs
+++ b/CertiPay.Common.Notifications/Notifications/ServiceSender.cs
@@ -4,6 +4,7 @@ using RestSharp.Serializers;
 using System;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CertiPay.Notifications
@@ -36,6 +37,11 @@ namespace CertiPay.Notifications
 
         public async Task SendAsync(SMSNotification notification)
         {
+            await SendAsync(notification, CancellationToken.None);
+        }
+
+        public async Task SendAsync(SMSNotification notification, CancellationToken token)
+        {
             using (Log.Timer("ServiceSender.SendAsync", context: notification, warnIfExceeds: this.Timeout))
             {
                 await Post("/SMS", notification);
@@ -43,6 +49,11 @@ namespace CertiPay.Notifications
         }
 
         public async Task SendAsync(EmailNotification notification)
+        {
+            await SendAsync(notification, CancellationToken.None);
+        }
+
+        public async Task SendAsync(EmailNotification notification,CancellationToken token)
         {
             using (Log.Timer("ServiceSender.SendAsync", context: notification, warnIfExceeds: this.Timeout))
             {


### PR DESCRIPTION
In WorkSafePays Email sender application we have a timeout needs to be implemented. So if an email was not send with in the timeout we should cancel the send. Since the existing method is implemented as SendAsync, to abort safely we need an overload which takes a cancellation token.